### PR TITLE
Edit wlroots and libxcb-errors path

### DIFF
--- a/godot.nix
+++ b/godot.nix
@@ -11,7 +11,7 @@ let
     pulseaudio = false;
   };
   xvfb-run = callPackage ./xvfb-run.nix { };
-  wlroots = callPackage ../wlroots/wlroots.nix { };
+  wlroots = callPackage ../wlroots { };
 
 	/* Modify a stdenv so that it produces debug builds; that is,
 		binaries have debug info, and compiler optimisations are
@@ -39,7 +39,7 @@ let
 
 
 
-  libxcb-errors = import ../wlroots/libxcb-errors/libxcb-errors.nix { stdenv = stdenv; pkg-config=pkg-config; autoreconfHook = autoreconfHook; xorg = xorg; libbsd = libbsd; python310 = python310; lib = lib; };
+  libxcb-errors = import ../wlroots/libxcb-errors { stdenv = stdenv; pkg-config=pkg-config; autoreconfHook = autoreconfHook; xorg = xorg; libbsd = libbsd; python310 = python310; lib = lib; };
 
   nixGLIntel = (callPackage ./nixGL.nix { }).nixGLIntel;
   nixGLRes = if (onNixOS == true) then " " else " ${nixGLIntel}/bin/nixGLIntel ";


### PR DESCRIPTION
# Why did I create this PR
Because of https://github.com/SimulaVR/wlroots/pull/1 , libxcb-errors and wlroots cannot be built in godot Derivation. Because I moved `/wlroots.nix` and `/libxcb-errors.nix` to each `/default.nix`. Therefore I created this PR to change the paths.

This PR is created for https://github.com/SimulaVR/Simula/pull/208.

# Changes
- Edit paths as `/libxcb-errors/libxcb-errors.nix` to `/libxcb-errors`, in order to use `/libxcb-errors/default.nix`