### PR TITLE
chore(editorconfig): Apply EditorConfig for Nix files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,11 @@ end_of_line = lf
 indent_style = tab
 insert_final_newline = true
 
+[*.nix]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+
 [*.{cpp,hpp,c,h,mm}]
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
# Purposes

Why not use space indentation for Nix files?