### PR TITLE
build(flakes): Update nixpkgs from `nixos-25.11` to `nixpkgs-unstable`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,7 +23,7 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
-          "wlroots-flake",
+          "wlroots",
           "nixpkgs"
         ]
       },
@@ -41,34 +41,34 @@
         "type": "github"
       }
     },
-    "libxcb-errors": {
-      "flake": false,
+    "nixpkgs": {
       "locked": {
-        "lastModified": 1732504353,
-        "narHash": "sha256-LPNRkLQSTPkCRIc9lhHYIvQs8ags3GpGehCWLY5qvJw=",
-        "owner": "SimulaVR",
-        "repo": "libxcb-errors",
-        "rev": "cb26a7dc442b0bb37f8648986350291d3d45a47a",
+        "lastModified": 1771207753,
+        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
         "type": "github"
       },
       "original": {
-        "owner": "SimulaVR",
-        "repo": "libxcb-errors",
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770464364,
-        "narHash": "sha256-z5NJPSBwsLf/OfD8WTmh79tlSU8XgIbwmk6qB1/TFzY=",
+        "lastModified": 1771207753,
+        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
+        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -79,7 +79,7 @@
         "nixpkgs": "nixpkgs",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix",
-        "wlroots-flake": "wlroots-flake"
+        "wlroots": "wlroots"
       }
     },
     "systems": {
@@ -132,30 +132,46 @@
         "type": "github"
       }
     },
-    "wlroots-flake": {
+    "treefmt-nix_2": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
-        "libxcb-errors": "libxcb-errors",
         "nixpkgs": [
+          "wlroots",
           "nixpkgs"
-        ],
-        "systems": "systems_2"
+        ]
       },
       "locked": {
-        "lastModified": 1770499572,
-        "narHash": "sha256-VzIH7zAGq7JIudl1z1MuQqOcSJRjOLzL0x9AwwAuNow=",
-        "ref": "refs/heads/simula",
-        "rev": "e1529945c8b87f1d65c48e1b036eb54b0b707c67",
-        "revCount": 3592,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/SimulaVR/wlroots"
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
       },
       "original": {
-        "rev": "e1529945c8b87f1d65c48e1b036eb54b0b707c67",
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/SimulaVR/wlroots"
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "wlroots": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2",
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1771822792,
+        "narHash": "sha256-OVI3AkAHDRn3nmztY79mT5BS8oelT/bZz7rFxL2LZ4Y=",
+        "owner": "SimulaVR",
+        "repo": "wlroots",
+        "rev": "9f8f9455a5785a43d538e5df68a27d1089daddec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SimulaVR",
+        "repo": "wlroots",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default-linux";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -10,11 +10,7 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    wlroots-flake = {
-      url = "git+https://github.com/SimulaVR/wlroots?rev=e1529945c8b87f1d65c48e1b036eb54b0b707c67&submodules=1";
-      inputs.nixpkgs.follows = "nixpkgs";
-      flake = true;
-    };
+    wlroots.url = "github:SimulaVR/wlroots";
   };
 
   outputs =
@@ -40,40 +36,7 @@
             rev = "88cbe52ee28219fc77194a1c87d71de3ce0be127";
             hash = "sha256-CLygKinJGAxFMQme/+UIX6smqgP1aaf5VBhPZCIbH2g=";
           };
-          wlroots = inputs.wlroots-flake.packages.${system}.default;
-
-          libxcb-errors = pkgs.stdenv.mkDerivation {
-            pname = "libxcb-errors";
-            version = "0.0.0";
-            src = pkgs.fetchFromGitHub {
-              owner = "SimulaVR";
-              repo = "libxcb-errors";
-              rev = "cb26a7dc442b0bb37f8648986350291d3d45a47a";
-              hash = "sha256-LPNRkLQSTPkCRIc9lhHYIvQs8ags3GpGehCWLY5qvJw=";
-            };
-
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              pkgs.python310
-              pkgs.autoreconfHook
-            ];
-
-            buildInputs = [
-              pkgs.xorg.libxcb
-              pkgs.xorg.libXau
-              pkgs.xorg.libXdmcp
-              pkgs.libbsd
-              pkgs.xorg.utilmacros
-              pkgs.xorg.xcbproto
-            ];
-
-            meta = {
-              description = "Allow XCB errors to print less opaquely";
-              homepage = "https://github.com/SimulaVR/libxcb-errors";
-              license = lib.licenses.mit;
-              platforms = lib.platforms.linux;
-            };
-          };
+          wlroots = inputs.wlroots.packages.${system}.default;
 
           godot = pkgs.stdenv.mkDerivation {
             pname = "godot";
@@ -146,13 +109,13 @@
             pkgs.autoPatchelfHook
           ];
           buildInputs = [
-            pkgs.xorg.libxcb
-            pkgs.xorg.libX11
-            pkgs.xorg.libXcursor
-            pkgs.xorg.libXinerama
-            pkgs.xorg.libXext
-            pkgs.xorg.libXrandr
-            pkgs.xorg.libXi
+            pkgs.libxcb
+            pkgs.libX11
+            pkgs.libXcursor
+            pkgs.libXinerama
+            pkgs.libXext
+            pkgs.libXrandr
+            pkgs.libXi
             pkgs.libGLU
             pkgs.zlib
 
@@ -169,7 +132,7 @@
             pkgs.libgbm
             pkgs.mesa
 
-            libxcb-errors
+            pkgs.libxcb-errors
             wlroots
           ];
         in

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,8 @@
           };
 
           tools.lsp = [
-            pkgs.nil
+            pkgs.nil # Nix
+            pkgs.clang-tools # C / C++
           ];
           tools.build = [
             pkgs.just

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,7 @@
 
             pkgs.libxkbcommon
             pkgs.wayland
+            pkgs.wayland-protocols
             pkgs.pixman
             pkgs.dbus-glib
             pkgs.libdrm

--- a/thirdparty/embree/kernels/geometry/pointi.h
+++ b/thirdparty/embree/kernels/geometry/pointi.h
@@ -212,7 +212,7 @@ namespace embree
     /*! output operator */
     friend __forceinline embree_ostream operator<<(embree_ostream cout, const PointMi& line)
     {
-      return cout << "Line" << M << "i {" << line.v0 << ", " << line.geomID() << ", " << line.primID() << "}";
+      return cout << "Line" << M << "i {" << line.geomID() << ", " << line.primID() << "}";
     }
 
    public:

--- a/thirdparty/embree/kernels/subdiv/bezier_curve.h
+++ b/thirdparty/embree/kernels/subdiv/bezier_curve.h
@@ -135,7 +135,7 @@ namespace embree
       }
       
       friend embree_ostream operator<<(embree_ostream cout, const QuadraticBezierCurve& a) {
-        return cout << "QuadraticBezierCurve ( (" << a.u.lower << ", " << a.u.upper << "), " << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
+        return cout << "QuadraticBezierCurve (" << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
       }
     };
   


### PR DESCRIPTION
This PR's reasons are same as https://github.com/SimulaVR/wlroots/pull/5 .

## Purposes

- To update buildInputs & nativeBuildInputs from hard-coding to some variables.
- To use `nixpkgs-unstable` instead of `nixos-25.11`.

## Why I create this PR to update to `nixpkgs-unstable`

That's because we don't have any reasons to use versioned nixpkgs (I might miss other reasons so it's not 100% accurate). I suggest a pattern for `flake.nix`, to use other flake's outputs. The following code block is it.

```nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
  inputs.godot.url = "github:SimulaVR/godot"; # The input, godot already has `nixpkgs-unstable`, so it doesn't depend this example's nixpkgs input.

  outputs =
  # ... 
}
```

There are two reasons for adopting this PR (the first one is the above one). Now nixpkgs-unstable branch has `pkgs.libxcb-errors` attribute, so we can reduce the dependency, [github.com/SimulaVR/libxcb-errors](https://github.com/SimulaVR/libxcb-errors).

...If we use [github.com/SimulaVR/libxcb-errors](https://github.com/SimulaVR/libxcb-errors) still, to update our custom libxcb-errors, of cource we cannot delete our libxcb-errors' repo.